### PR TITLE
Fixed get_fid() to work for all cases

### DIFF
--- a/drive_cli/utils.py
+++ b/drive_cli/utils.py
@@ -158,11 +158,15 @@ def modified_or_created(sync_time, item_path):
 
 
 def get_fid(inp):
-    if 'drive' in inp:
+    if 'google' in inp:
         if 'open' in inp:
             fid = inp.split('=')[-1]
+        elif 'folders' in inp:
+            fid = inp.split('/')[-1]
+            if '?' in fid:
+                fid = fid.split('?')[-2]
         else:
-            fid = inp.split('/')[-1].split('?')[0]
+            fid = inp.split('/')[-2]
     else:
         fid = inp
     return fid


### PR DESCRIPTION
Solves issue #19 
Some test cases I tried :

inp1 = "https://drive.google.com/file/d/1NKaxkeqEas9GuKc82Thg6jwDxjyOB7Hn/view?usp=sharing"
inp2 = "https://drive.google.com/open?id=1dsUNzft7kOq9q73j1nOqQvUeaiMsf0LG"
inp3 = "https://drive.google.com/open?id=1RB50FiG7Oy9FEJJLgB8XtoyZUDKgYaAkArJxx5RtaUo"
inp9 = "https://docs.google.com/document/d/1RB50FiG7Oy9FEJJLgB8XtoyZUDKgYaAkArJxx5RtaUo/edit"
inp11 = "https://sites.google.com/s/1_Ds3PonjphAMFPqqaQUHYiQwjgENaFQy/p/1HEPiDmER8TB5x1yW9lb4fUnu4JF-lbf6/edit?authuser=2"
inp14 = "https://drive.google.com/drive/folders/1MHUBvFafcpk_xEtPdPYOnvlFWwDU8R6u?usp=sharing"
inp15 = "https://drive.google.com/open?id=1MHUBvFafcpk_xEtPdPYOnvlFWwDU8R6u"
inp16 = "https://drive.google.com/drive/folders/1MHUBvFafcpk_xEtPdPYOnvlFWwDU8R6u"