### PR TITLE
fix 

### DIFF
--- a/drive_cli/utils.py
+++ b/drive_cli/utils.py
@@ -369,7 +369,7 @@ def upload_file(name, path, pid):
         'parents': [pid],
         'mimeType': file_mimeType
     }
-    if os.stat(filename).st_size <= 256*1024:
+    if os.stat(path).st_size <= 256*1024:
         media = MediaFileUpload(path, mimetype=file_mimeType)
         new_file = service.files().create(body=file_metadata,
                                       media_body=media,

--- a/drive_cli/utils.py
+++ b/drive_cli/utils.py
@@ -369,10 +369,23 @@ def upload_file(name, path, pid):
         'parents': [pid],
         'mimeType': file_mimeType
     }
-    media = MediaFileUpload(path, mimetype=file_mimeType)
-    new_file = service.files().create(body=file_metadata,
+    if os.stat(filename).st_size <= 256*1024:
+        media = MediaFileUpload(path, mimetype=file_mimeType)
+        new_file = service.files().create(body=file_metadata,
                                       media_body=media,
                                       fields='id').execute()
+    else:
+        CHUNK_SIZE_MB = 1 #MB. You may want to increase the size to a higher speed if the network restrictions allow
+        media = MediaFileUpload(
+                path, mimetype=file_mimeType,
+                chunksize=1024*1024*1, resumable=True)
+        status, new_file = None, None
+        req = service.files().create(body=file_metadata,
+                                          media_body=media,
+                                          fields='id')
+        while new_file is None:
+            status, new_file = req.next_chunk()
+    
     data = drive_data()
     data[path] = {'id': new_file['id'], 'time': time.time()}
     drive_data(data)


### PR DESCRIPTION
Fix #74 ( & #77 ??)
Use `resumable upload` if the file is larger than 256MB