### PR TITLE
Allow creating folders recursively

### DIFF
--- a/drive_cli/utils.py
+++ b/drive_cli/utils.py
@@ -424,7 +424,7 @@ def pull_content(cwd, fid):
         else:
             if(not os.path.exists(dir_name)):
                 click.secho("creating: " + dir_name)
-                os.mkdir(dir_name)
+                os.makedirs(dir_name)
                 data = drive_data()
                 data[dir_name] = {'id': item['id'], 'time': time.time()}
                 data = drive_data(data)


### PR DESCRIPTION
When downloading a drive folder with intermediary directories that
do not contain any files like
```
root/
└── dir1/
    └── dir2/
    	└── file.ext
```
the corresponding `drive clone` fails.
Before this commit, `os.mkdir()` was used which fails because it
assumes that `dir1` exists and only creates `dir2`.
After this commit, `os.makedirs()` is used which creates all
required intermediary directories.