### PR TITLE
Slashes in filenames no longer cause a crash

### DIFF
--- a/drive_cli/utils.py
+++ b/drive_cli/utils.py
@@ -417,6 +417,7 @@ def pull_content(cwd, fid):
         if page_token is None:
             break
     for item in lis:
+        item['name'] = item['name'].replace("/","-")
         dir_name = os.path.join(cwd, item['name'])
         if(item['mimeType'] != 'application/vnd.google-apps.folder'):
             if((not os.path.exists(dir_name)) or write_needed(dir_name, item)):


### PR DESCRIPTION
I ran into an issue when downloading a folder that contained files that had "/" in their filenames. This caused a problem with finding the correct path to write the file to. 

A quick fix was replacing slashes with hyphens. 